### PR TITLE
Release 1.0

### DIFF
--- a/ManUp.podspec
+++ b/ManUp.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "ManUp"
-  s.version          = "0.7"
+  s.version          = "1.0"
   s.summary          = "A server side check of the app version and configuration options for your iOS/tvOS app."
 
   s.description      = <<-DESC

--- a/ManUp/ManUp.h
+++ b/ManUp/ManUp.h
@@ -61,7 +61,7 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 /**
  The URL pointing to the remote config.json file.
  */
-@property (nonatomic, strong, nullable) NSURL *serverConfigURL;
+@property (nonatomic, strong, nullable) NSURL *configURL;
 
 /**
  The date that the configuration was last successfully updated from the server.

--- a/ManUp/ManUp.h
+++ b/ManUp/ManUp.h
@@ -41,16 +41,16 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 
 @interface ManUp : NSObject
 
-+ (ManUp *)sharedInstance;
+- (instancetype)initWithConfigURL:(nullable NSURL *)url delegate:(nullable NSObject<ManUpDelegate> *)delegate;
 
-- (void)manUpWithDefaultDictionary:(nullable NSDictionary *)defaultSettingsDict
-                   serverConfigURL:(nullable NSURL *)serverConfigURL
-                          delegate:(nullable NSObject<ManUpDelegate> *)delegate;
+/**
+ Run the ManUp validation, if it's already running it will not start another check.
+ */
+- (void)validate;
 
-- (void)manUpWithDefaultJSONFile:(nullable NSString *)defaultSettingsPath
-                 serverConfigURL:(nullable NSURL *)serverConfigURL
-                        delegate:(nullable NSObject<ManUpDelegate> *)delegate;
-
+/**
+ A delegate to receive callbacks during the lifecycle of a validation.
+ */
 @property (nonatomic, weak, nullable) NSObject<ManUpDelegate> *delegate;
 
 /**
@@ -61,7 +61,7 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 /**
  The URL pointing to the remote config.json file.
  */
-@property (nonatomic, readonly, nullable) NSURL *serverConfigURL;
+@property (nonatomic, strong, nullable) NSURL *serverConfigURL;
 
 /**
  The date that the configuration was last successfully updated from the server.
@@ -78,7 +78,7 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
  
  @param key the key used in the config json file
  */
-+ (id)settingForKey:(NSString *)key;
+- (id)settingForKey:(NSString *)key;
 
 /** 
  String version comparison

--- a/ManUp/ManUp.h
+++ b/ManUp/ManUp.h
@@ -24,6 +24,7 @@ static NSString *const kManUpConfigAppVersionCurrent    = @"latest";
 static NSString *const kManUpConfigAppVersionMin        = @"minimum";
 static NSString *const kManUpConfigAppUpdateURL         = @"url";
 static NSString *const kManUpConfigAppDeploymentTarget  = @"target";
+static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 
 @protocol ManUpDelegate <NSObject>
 
@@ -34,6 +35,7 @@ static NSString *const kManUpConfigAppDeploymentTarget  = @"target";
 - (BOOL)manUpShouldShowAlert;
 - (void)manUpUpdateRequired;
 - (void)manUpUpdateAvailable;
+- (void)manUpMaintenanceMode;
 
 @end
 

--- a/ManUp/ManUp.h
+++ b/ManUp/ManUp.h
@@ -14,15 +14,16 @@ NS_ASSUME_NONNULL_BEGIN
  Default config.json keys
  Use these keys in your applications config json file to be served to ManUp
  
-    manUpAppVersionCurrent: the current App Store version, eg 2.0
-    manUpAppVersionMin: the minimum required version, which will force a mandatory update, eg 1.1
-    manUpAppUpdateURL: the URL to be opened to update the app, eg an App Store URL or a website
-    manUpAppDeploymentTarget: the minimum required OS for this update, optional, eg 8.1
+    latest: the current App Store version, eg 2.0
+    minimum: the minimum required version, which will force a mandatory update, eg 1.1
+    url: the URL to be opened to update the app, eg an App Store URL or a website
+    target: the minimum required OS for this update, optional, eg 8.1
  */
-static NSString *const kManUpConfigAppVersionCurrent    = @"manUpAppVersionCurrent";
-static NSString *const kManUpConfigAppVersionMin        = @"manUpAppVersionMin";
-static NSString *const kManUpConfigAppUpdateURL         = @"manUpAppUpdateURL";
-static NSString *const kManUpConfigAppDeploymentTarget  = @"manUpAppDeploymentTarget";
+static NSString *const kManUpConfigiOSContainer         = @"ios";
+static NSString *const kManUpConfigAppVersionCurrent    = @"latest";
+static NSString *const kManUpConfigAppVersionMin        = @"minimum";
+static NSString *const kManUpConfigAppUpdateURL         = @"url";
+static NSString *const kManUpConfigAppDeploymentTarget  = @"target";
 
 @protocol ManUpDelegate <NSObject>
 

--- a/ManUp/ManUp.m
+++ b/ManUp/ManUp.m
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
  Used to save settings used by ManUp locally to the device
  */
 static NSString *const kManUpSettings                   = @"ManUpSettings";
-static NSString *const kManUpServerConfigURL            = @"ManUpServerConfigURL";
 static NSString *const kManUpLastUpdated                = @"ManUpLastUpdated";
 
 typedef NS_ENUM(NSUInteger, ManUpAlertType) {
@@ -40,7 +39,7 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
 
 - (instancetype)initWithConfigURL:(nullable NSURL *)url delegate:(nullable NSObject<ManUpDelegate> *)delegate {
     if (self = [self init]) {
-        self.serverConfigURL = url;
+        self.configURL = url;
         self.delegate = delegate;
     }
     return self;
@@ -133,7 +132,7 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
 #pragma mark -
 
 - (void)updateFromServer {
-    if (!self.serverConfigURL) {
+    if (!self.configURL) {
         [self log:@"ERROR: No server config URL specified."];
         if ([self.delegate respondsToSelector:@selector(manUpConfigUpdateFailed:)]) {
             NSError *error = [NSError errorWithDomain:@"com.nextfaze.ManUp" code:1 userInfo:nil];
@@ -152,7 +151,7 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
         [self.delegate manUpConfigUpdateStarting];
     }
     
-    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:self.serverConfigURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60];
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:self.configURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60];
 
     NSURLSession *session = [NSURLSession sharedSession];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request

--- a/ManUp/ManUp.m
+++ b/ManUp/ManUp.m
@@ -31,63 +31,34 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
 @property (nonatomic, assign) ManUpAlertType currentlyShownAlertType;
 @property (nonatomic, assign) BOOL optionalUpdateShown;
 @property (nonatomic, assign) BOOL updateInProgress;
-@property (nonatomic, strong, nullable) NSURL *serverConfigURL;
 
 @end
 
 @implementation ManUp
 
-- (void)manUpWithDefaultDictionary:(nullable NSDictionary *)defaultSettingsDict serverConfigURL:(nullable NSURL *)serverConfigURL delegate:(nullable NSObject<ManUpDelegate> *)delegate {
-    self.delegate = delegate;
-    self.serverConfigURL = serverConfigURL;
-    
-    // Only apply defaults if they do not exist already.
-    if(![self hasPersistedSettings]) {
-        NSDictionary* nonNullDefaultSettings = [self replaceNullsWithEmptyStringInDictionary:defaultSettingsDict];
-        [self setManUpSettings:nonNullDefaultSettings];
-    }
-    
-    [self updateFromServer];
-}
-
-- (void)manUpWithDefaultJSONFile:(nullable NSString *)defaultSettingsPath serverConfigURL:(nullable NSURL *)serverConfigURL delegate:(nullable NSObject<ManUpDelegate> *)delegate {
-    self.delegate = delegate;
-    self.serverConfigURL = serverConfigURL;
-    
-    // Only apply defaults if they do not exist already.
-    if (![self hasPersistedSettings]) {
-        NSData *jsonData = [NSData dataWithContentsOfFile:defaultSettingsPath];
-        if (jsonData) {
-            NSError *error = nil;
-            NSDictionary *defaultSettings = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-            NSDictionary *nonNullDefaultSettings = [self replaceNullsWithEmptyStringInDictionary:defaultSettings];
-            [self setManUpSettings:nonNullDefaultSettings];
-        }
-    }
-    
-    [self updateFromServer];
-}
-
 #pragma mark - Creation
 
-+ (ManUp *)sharedInstance {
-    static id sharedInstance = nil;
-    
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedInstance = [[[self class] alloc] init];
-    });
-
-    return sharedInstance;
+- (instancetype)initWithConfigURL:(nullable NSURL *)url delegate:(nullable NSObject<ManUpDelegate> *)delegate {
+    if (self = [self init]) {
+        self.serverConfigURL = url;
+        self.delegate = delegate;
+    }
+    return self;
 }
 
-- (id)init {
+- (instancetype)init {
 	if (self = [super init]) {
 		self.updateInProgress = NO;
         self.optionalUpdateShown = NO;
         self.currentlyShownAlertType = ManUpAlertTypeNone;
 	}
 	return self;
+}
+
+#pragma mark - Public
+
+- (void)validate {
+    [self updateFromServer];
 }
 
 #pragma mark - 
@@ -148,10 +119,6 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
         object = iOSSettings[resolvedKey];
     }
     return object;
-}
-
-+ (id)settingForKey:(NSString *)key {
-    return [[ManUp sharedInstance] settingForKey:key];
 }
 
 - (void)log:(NSString *)string, ... NS_FORMAT_FUNCTION(1,2) {

--- a/ManUp/ManUp.m
+++ b/ManUp/ManUp.m
@@ -313,8 +313,8 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
     
     if (!enabled) {
         [self showAlertOfType:ManUpAlertTypeMaintenanceMode
-                    withTitle:[NSString stringWithFormat:NSLocalizedString(@"%@ Unavailable", nil), appName]
-                      message:[NSString stringWithFormat:NSLocalizedString(@"%@ is currently unavailable. Please check back later.", nil), appName]
+                    withTitle:[NSString stringWithFormat:NSLocalizedString(@"%@ Unavailable", @"{app name} Unavailable"), appName]
+                      message:[NSString stringWithFormat:NSLocalizedString(@"%@ is currently unavailable. Please check back later.", @"{app name} is currently unavailable..."), appName]
                       actions:@[]];
         
         if ([self.delegate respondsToSelector:@selector(manUpMaintenanceMode)]) {

--- a/ManUp/ManUp.m
+++ b/ManUp/ManUp.m
@@ -130,9 +130,16 @@ static NSString *const kManUpLastUpdated                = @"ManUpLastUpdated";
 }
 
 - (id)settingForKey:(NSString *)key {
-    NSDictionary *settingsDictionary = [[NSUserDefaults standardUserDefaults] valueForKey:kManUpSettings];
+    NSDictionary *settings = [[NSUserDefaults standardUserDefaults] valueForKey:kManUpSettings];
     NSString *resolvedKey = self.customConfigKeyMapping[key] ?: key;
-    return settingsDictionary[resolvedKey];
+    id object = settings[resolvedKey];
+    if (object == nil) {
+        // value not found at the root level, also check inside the `ios` object
+        NSString *iOSKey = self.customConfigKeyMapping[kManUpConfigiOSContainer] ?: kManUpConfigiOSContainer;
+        NSDictionary *iOSSettings = settings[iOSKey];
+        object = iOSSettings[resolvedKey];
+    }
+    return object;
 }
 
 + (id)settingForKey:(NSString *)key {

--- a/ManUpDemo/ManUpDemo.xcodeproj/project.pbxproj
+++ b/ManUpDemo/ManUpDemo.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		7C03353C1CB216C90076CA8B /* TestCustomConfigKeys.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C03353B1CB216C90076CA8B /* TestCustomConfigKeys.json */; };
 		7C03353D1CB216C90076CA8B /* TestCustomConfigKeys.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C03353B1CB216C90076CA8B /* TestCustomConfigKeys.json */; };
+		7C1545BC1FB56277008AC0E0 /* TestMaintenanceMode.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C1545BB1FB56277008AC0E0 /* TestMaintenanceMode.json */; };
+		7C1545BD1FB56277008AC0E0 /* TestMaintenanceMode.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C1545BB1FB56277008AC0E0 /* TestMaintenanceMode.json */; };
 		7C239A661DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget9.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C239A631DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget9.json */; };
 		7C239A671DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget9.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C239A631DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget9.json */; };
 		7C239A681DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget10.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C239A641DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget10.json */; };
@@ -64,6 +66,7 @@
 		647615055885DA5DD386E54D /* libPods-ManUpDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ManUpDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		666C04EE96A11222E26C2145 /* Pods-ManUpDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ManUpDemoTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ManUpDemoTests/Pods-ManUpDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7C03353B1CB216C90076CA8B /* TestCustomConfigKeys.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestCustomConfigKeys.json; sourceTree = "<group>"; };
+		7C1545BB1FB56277008AC0E0 /* TestMaintenanceMode.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestMaintenanceMode.json; sourceTree = "<group>"; };
 		7C239A631DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget9.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestUpgradeAvailableDeploymentTarget9.json; sourceTree = "<group>"; };
 		7C239A641DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget10.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestUpgradeAvailableDeploymentTarget10.json; sourceTree = "<group>"; };
 		7C239A651DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget11.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = TestUpgradeAvailableDeploymentTarget11.json; sourceTree = "<group>"; };
@@ -182,6 +185,7 @@
 			isa = PBXGroup;
 			children = (
 				7C03353B1CB216C90076CA8B /* TestCustomConfigKeys.json */,
+				7C1545BB1FB56277008AC0E0 /* TestMaintenanceMode.json */,
 				7CB87B7C1CAE14EB0006CB79 /* TestMinVersionGreaterThanCurrent.json */,
 				7CB87B7D1CAE14EB0006CB79 /* TestMinVersionLessThanCurrent.json */,
 				7C239A6C1DF0F7500099D534 /* TestUpgradeAvailableDeploymentTarget8.json */,
@@ -316,6 +320,7 @@
 				7C239A681DEFDFC00099D534 /* TestUpgradeAvailableDeploymentTarget10.json in Resources */,
 				7CB87B831CAE14EB0006CB79 /* TestMinVersionLessThanCurrent.json in Resources */,
 				7C239A6D1DF0F7500099D534 /* TestUpgradeAvailableDeploymentTarget8.json in Resources */,
+				7C1545BC1FB56277008AC0E0 /* TestMaintenanceMode.json in Resources */,
 				7CB87B871CAE14EB0006CB79 /* TestUpgradeAvailableWithURL.json in Resources */,
 				7C404B321FAC3470001E649E /* TestUpgradeAvailableDeploymentTarget12.json in Resources */,
 				7C3106181C6D8DBB005E9578 /* Assets.xcassets in Resources */,
@@ -337,6 +342,7 @@
 				7C03353D1CB216C90076CA8B /* TestCustomConfigKeys.json in Resources */,
 				7C404B351FAC3470001E649E /* TestUpgradeAvailableDeploymentTarget14.json in Resources */,
 				7C404B391FAC3470001E649E /* TestUpgradeAvailableDeploymentTarget15.json in Resources */,
+				7C1545BD1FB56277008AC0E0 /* TestMaintenanceMode.json in Resources */,
 				7C239A6E1DF0F7500099D534 /* TestUpgradeAvailableDeploymentTarget8.json in Resources */,
 				7CB87B881CAE14EB0006CB79 /* TestUpgradeAvailableWithURL.json in Resources */,
 				7CB87B8A1CAE14EB0006CB79 /* TestVersionsEqual.json in Resources */,

--- a/ManUpDemo/ManUpDemo/DemoViewController.m
+++ b/ManUpDemo/ManUpDemo/DemoViewController.m
@@ -96,7 +96,7 @@
         self.manUp.customConfigKeyMapping = nil;
     }
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:serverPath];
+    self.manUp.configURL = [NSURL URLWithString:serverPath];
     [self.manUp validate];
 }
 

--- a/ManUpDemo/ManUpDemo/DemoViewController.m
+++ b/ManUpDemo/ManUpDemo/DemoViewController.m
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) NSArray *testItems;
 
+@property (nonatomic, strong) ManUp *manUp;
 @property (nonatomic, strong) NSString *lastUsedFilename;
 
 @end
@@ -33,6 +34,10 @@
     }
     
     self.testItems = testItems;
+    
+    self.manUp = [[ManUp alloc] init];
+    self.manUp.delegate = self;
+    self.manUp.enableConsoleLogging = YES;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
     
@@ -79,23 +84,20 @@
     
     NSString *serverPath = [@"https://github.com/NextFaze/ManUp/raw/develop/ManUpDemo/TestFiles/" stringByAppendingString:fileName];
     
-    [ManUp sharedInstance].enableConsoleLogging = YES;
-    
     if ([fileName isEqualToString:@"TestCustomConfigKeys.json"]) {
         // Don't like the json keys used by ManUp? Specify your own with a custom mapping dictionary
-        [ManUp sharedInstance].customConfigKeyMapping = @{
-                                                          kManUpConfigAppVersionCurrent: @"app_store_version_current",
-                                                          kManUpConfigAppVersionMin: @"minimum_allowed_version",
-                                                          kManUpConfigAppUpdateURL: @"app_update_url"
-                                                          };
+        self.manUp.customConfigKeyMapping = @{
+                                              kManUpConfigAppVersionCurrent: @"app_store_version_current",
+                                              kManUpConfigAppVersionMin: @"minimum_allowed_version",
+                                              kManUpConfigAppUpdateURL: @"app_update_url"
+                                              };
         
     } else {
-        [ManUp sharedInstance].customConfigKeyMapping = nil;
+        self.manUp.customConfigKeyMapping = nil;
     }
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:[fileName stringByDeletingPathExtension] ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:serverPath]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:serverPath];
+    [self.manUp validate];
 }
 
 #pragma mark - UITableViewDataSource

--- a/ManUpDemo/ManUpDemo/DemoViewController.m
+++ b/ManUpDemo/ManUpDemo/DemoViewController.m
@@ -14,6 +14,8 @@
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) NSArray *testItems;
 
+@property (nonatomic, strong) NSString *lastUsedFilename;
+
 @end
 
 @implementation DemoViewController
@@ -31,6 +33,8 @@
     }
     
     self.testItems = testItems;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
     
     return self;
 }
@@ -60,6 +64,40 @@
     self.tableView.frame = self.view.bounds;
 }
 
+#pragma mark - Public
+
+- (void)applicationDidBecomeActive {
+    if (self.lastUsedFilename != nil) {
+        [self runManUpWithFileName:self.lastUsedFilename];
+    }
+}
+
+#pragma mark - Private
+
+- (void)runManUpWithFileName:(NSString *)fileName {
+    self.lastUsedFilename = fileName;
+    
+    NSString *serverPath = [@"https://github.com/NextFaze/ManUp/raw/develop/ManUpDemo/TestFiles/" stringByAppendingString:fileName];
+    
+    [ManUp sharedInstance].enableConsoleLogging = YES;
+    
+    if ([fileName isEqualToString:@"TestCustomConfigKeys.json"]) {
+        // Don't like the json keys used by ManUp? Specify your own with a custom mapping dictionary
+        [ManUp sharedInstance].customConfigKeyMapping = @{
+                                                          kManUpConfigAppVersionCurrent: @"app_store_version_current",
+                                                          kManUpConfigAppVersionMin: @"minimum_allowed_version",
+                                                          kManUpConfigAppUpdateURL: @"app_update_url"
+                                                          };
+        
+    } else {
+        [ManUp sharedInstance].customConfigKeyMapping = nil;
+    }
+    
+    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:[fileName stringByDeletingPathExtension] ofType:@"json"]
+                                     serverConfigURL:[NSURL URLWithString:serverPath]
+                                            delegate:self];
+}
+
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
@@ -80,25 +118,7 @@
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
     
     NSString *fileName = self.testItems[indexPath.item];
-    NSString *serverPath = [@"https://github.com/NextFaze/ManUp/raw/develop/ManUpDemo/TestFiles/" stringByAppendingString:fileName];
-
-    [ManUp sharedInstance].enableConsoleLogging = YES;
-    
-    if ([fileName isEqualToString:@"TestCustomConfigKeys.json"]) {
-        // Don't like the json keys used by ManUp? Specify your own with a custom mapping dictionary
-        [ManUp sharedInstance].customConfigKeyMapping = @{
-                                                          kManUpConfigAppVersionCurrent: @"app_store_version_current",
-                                                          kManUpConfigAppVersionMin: @"minimum_allowed_version",
-                                                          kManUpConfigAppUpdateURL: @"app_update_url"
-                                                          };
-        
-    } else {
-        [ManUp sharedInstance].customConfigKeyMapping = nil;
-    }
-    
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:[fileName stringByDeletingPathExtension] ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:serverPath]
-                                            delegate:self];
+    [self runManUpWithFileName:fileName];
 }
 
 #pragma mark - ManUpDelegate

--- a/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
+++ b/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
@@ -47,7 +47,7 @@
 }
 
 - (void)testConfigInvalidURL {
-    self.manUp.serverConfigURL = nil;
+    self.manUp.configURL = nil;
     [self.manUp validate];
     
     XCTAssert(self.failed == YES);
@@ -55,7 +55,7 @@
 }
     
 - (void)testConfigVersionsEqual {
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
@@ -76,7 +76,7 @@
     NSInteger lowerMajorVersion = operatingSystemMajorVersion - 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)lowerMajorVersion];
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is lower than the OS version"];
@@ -98,7 +98,7 @@
     NSInteger operatingSystemMajorVersion = [versionComponents[0] integerValue];
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)operatingSystemMajorVersion];
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is the same (major) as the OS version"];
@@ -121,7 +121,7 @@
     NSInteger higherMajorVersion = operatingSystemMajorVersion + 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)higherMajorVersion];
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update exists but is not available as the update's deployment target is higher than the OS version"];
@@ -135,7 +135,7 @@
 }
 
 - (void)testMaintenanceMode {
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with maintenance mode is true"];

--- a/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
+++ b/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
@@ -14,6 +14,7 @@
 @interface ManUpDemoTests : XCTestCase <ManUpDelegate>
 
 @property (nonatomic, strong) XCTestExpectation *expectation;
+@property (nonatomic, strong) ManUp *manUp;
 @property (nonatomic, assign) BOOL updated;
 @property (nonatomic, assign) BOOL failed;
 @property (nonatomic, assign) BOOL updateAvailable;
@@ -27,7 +28,8 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    [ManUp sharedInstance].enableConsoleLogging = YES;
+    self.manUp = [[ManUp alloc] initWithConfigURL:nil delegate:self];
+    self.manUp.enableConsoleLogging = YES;
 }
 
 - (void)tearDown {
@@ -37,53 +39,24 @@
     self.failed = NO;
     self.updateAvailable = NO;
     self.updateRequired = NO;
-    [ManUp sharedInstance].optionalUpdateShown = NO;
 }
 
 - (void)testManUpSettingForKey {
-    id setting = [ManUp settingForKey:@"made-up-key"];
+    id setting = [self.manUp settingForKey:@"made-up-key"];
     XCTAssertNil(setting, @"There should be no setting for this made up key.");
 }
 
 - (void)testConfigInvalidURL {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestVersionsEqual" ofType:@"json"]
-                                     serverConfigURL:nil
-                                            delegate:self];
+    self.manUp.serverConfigURL = nil;
+    [self.manUp validate];
     
     XCTAssert(self.failed == YES);
     XCTAssert(self.updated == NO);
 }
-
-- (void)testConfigWithIncorrectJSONFile {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"ThisFileDoesntExist" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]]
-                                            delegate:self];
-
-    self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
-    
-    [self waitForExpectationsWithTimeout:60.0 handler:nil];
-    
-    XCTAssert(self.failed == NO);
-    XCTAssert(self.updated == YES);
-}
-
-- (void)testConfigWithNilJSONFile {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:nil
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]]
-                                            delegate:self];
-    
-    self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
-    
-    [self waitForExpectationsWithTimeout:60.0 handler:nil];
-    
-    XCTAssert(self.failed == NO);
-    XCTAssert(self.updated == YES);
-}
     
 - (void)testConfigVersionsEqual {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestVersionsEqual" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
     
@@ -103,9 +76,8 @@
     NSInteger lowerMajorVersion = operatingSystemMajorVersion - 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)lowerMajorVersion];
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:testFilename ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is lower than the OS version"];
     
@@ -126,9 +98,8 @@
     NSInteger operatingSystemMajorVersion = [versionComponents[0] integerValue];
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)operatingSystemMajorVersion];
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:testFilename ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is the same (major) as the OS version"];
     
@@ -150,9 +121,8 @@
     NSInteger higherMajorVersion = operatingSystemMajorVersion + 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)higherMajorVersion];
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:testFilename ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update exists but is not available as the update's deployment target is higher than the OS version"];
     
@@ -165,9 +135,8 @@
 }
 
 - (void)testMaintenanceMode {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestMaintenanceMode" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with maintenance mode is true"];
     

--- a/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
+++ b/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
@@ -18,7 +18,8 @@
 @property (nonatomic, assign) BOOL failed;
 @property (nonatomic, assign) BOOL updateAvailable;
 @property (nonatomic, assign) BOOL updateRequired;
-    
+@property (nonatomic, assign) BOOL maintenanceMode;
+
 @end
 
 @implementation ManUpDemoTests
@@ -163,6 +164,22 @@
     XCTAssert(self.updateRequired == NO);
 }
 
+- (void)testMaintenanceMode {
+    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestMaintenanceMode" ofType:@"json"]
+                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]]
+                                            delegate:self];
+    
+    self.expectation = [self expectationWithDescription:@"ManUp with maintenance mode is true"];
+    
+    [self waitForExpectationsWithTimeout:60.0 handler:nil];
+    
+    XCTAssert(self.maintenanceMode == YES);
+    XCTAssert(self.failed == NO);
+    XCTAssert(self.updated == YES);
+    XCTAssert(self.updateAvailable == NO);
+    XCTAssert(self.updateRequired == NO);
+}
+
 #pragma mark - ManUpDelegate
 
 - (void)manUpConfigUpdateStarting {
@@ -196,6 +213,11 @@
 - (void)manUpUpdateRequired {
     NSLog(@"ManUpDelegate: update required");
     self.updateRequired = YES;
+}
+
+- (void)manUpMaintenanceMode {
+    NSLog(@"ManUpDelegate: maintenance mode");
+    self.maintenanceMode = YES;
 }
 
 @end

--- a/ManUpDemo/TestFiles/TestMaintenanceMode.json
+++ b/ManUpDemo/TestFiles/TestMaintenanceMode.json
@@ -1,0 +1,8 @@
+{
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "1.0",
+        "minimum": "1.0",
+        "enabled": false
+    }
+}

--- a/ManUpDemo/TestFiles/TestMinVersionGreaterThanCurrent.json
+++ b/ManUpDemo/TestFiles/TestMinVersionGreaterThanCurrent.json
@@ -1,5 +1,7 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "1.0",
-	"minimum": "2.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "1.0",
+        "minimum": "2.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestMinVersionGreaterThanCurrent.json
+++ b/ManUpDemo/TestFiles/TestMinVersionGreaterThanCurrent.json
@@ -1,5 +1,5 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "1.0",
-	"manUpAppVersionMin": "2.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "1.0",
+	"minimum": "2.0"
 }

--- a/ManUpDemo/TestFiles/TestMinVersionLessThanCurrent.json
+++ b/ManUpDemo/TestFiles/TestMinVersionLessThanCurrent.json
@@ -1,5 +1,5 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "2.0",
-	"manUpAppVersionMin": "1.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "2.0",
+	"minimum": "1.0"
 }

--- a/ManUpDemo/TestFiles/TestMinVersionLessThanCurrent.json
+++ b/ManUpDemo/TestFiles/TestMinVersionLessThanCurrent.json
@@ -1,5 +1,7 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "2.0",
-	"minimum": "1.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "2.0",
+        "minimum": "1.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget10.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget10.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "10.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "10.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget10.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget10.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "10.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "10.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget11.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget11.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "11.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "11.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget11.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget11.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "11.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "11.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget12.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget12.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "12.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "12.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget12.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget12.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "12.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "12.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget13.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget13.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "13.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "13.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget13.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget13.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "13.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "13.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget14.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget14.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "14.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "14.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget14.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget14.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "14.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "14.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget15.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget15.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "15.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "15.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget15.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget15.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "15.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "15.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget8.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget8.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "8.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "8.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget8.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget8.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "8.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "8.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget9.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget9.json
@@ -1,6 +1,8 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0",
-	"target": "9.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0",
+        "target": "9.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget9.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableDeploymentTarget9.json
@@ -1,6 +1,6 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0",
-	"manUpAppDeploymentTarget": "9.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0",
+	"target": "9.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableWithURL.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableWithURL.json
@@ -1,5 +1,7 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "99999.0",
-	"minimum": "1.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "99999.0",
+        "minimum": "1.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableWithURL.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableWithURL.json
@@ -1,5 +1,5 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "99999.0",
+	"minimum": "1.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableWithoutURL.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableWithoutURL.json
@@ -1,5 +1,5 @@
 {
-	"manUpAppUpdateURL": null,
-	"manUpAppVersionCurrent": "99999.0",
-	"manUpAppVersionMin": "1.0"
+	"url": null,
+	"latest": "99999.0",
+	"minimum": "1.0"
 }

--- a/ManUpDemo/TestFiles/TestUpgradeAvailableWithoutURL.json
+++ b/ManUpDemo/TestFiles/TestUpgradeAvailableWithoutURL.json
@@ -1,5 +1,7 @@
 {
-	"url": null,
-	"latest": "99999.0",
-	"minimum": "1.0"
+    "ios": {
+        "url": null,
+        "latest": "99999.0",
+        "minimum": "1.0"
+    }
 }

--- a/ManUpDemo/TestFiles/TestVersionsEqual.json
+++ b/ManUpDemo/TestFiles/TestVersionsEqual.json
@@ -1,5 +1,5 @@
 {
-	"manUpAppUpdateURL": "https://itunes.apple.com/app/id0000000?mt=8",
-	"manUpAppVersionCurrent": "1.0",
-	"manUpAppVersionMin": "1.0"
+	"url": "https://itunes.apple.com/app/id0000000?mt=8",
+	"latest": "1.0",
+	"minimum": "1.0"
 }

--- a/ManUpDemo/TestFiles/TestVersionsEqual.json
+++ b/ManUpDemo/TestFiles/TestVersionsEqual.json
@@ -1,5 +1,7 @@
 {
-	"url": "https://itunes.apple.com/app/id0000000?mt=8",
-	"latest": "1.0",
-	"minimum": "1.0"
+    "ios": {
+        "url": "https://itunes.apple.com/app/id0000000?mt=8",
+        "latest": "1.0",
+        "minimum": "1.0"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ Alterantively, you can simply copy the folder `ManUp` into your project.
 
 ManUp will download a ManUp configuration file (json) that is hosted on a server of your choice. This file will have the current app store version, the minimum version, and a URL to the app store or app website.
 
-    { 
-        "manUpAppUpdateLink": "https://itunes.apple.com/app/id0000000?mt=8",
-        "manUpAppVersionCurrent": "2.0",
-        "manUpAppVersionMin": "1.1"
+    {
+        "ios": {
+            "url": "https://itunes.apple.com/app/id0000000?mt=8",
+            "latest": "2.0",
+            "minimum": "1.1"
+        }
     }
 
-Running ManUp will download this file and compare it to the installed app's version to determine if there is an update available (`manUpAppVersionCurrent`), or if there is a mandatory update required (`manUpAppVersionMin`).
+Running ManUp will download this file and compare it to the installed app's version to determine if there is an update available (`latest`), or if there is a mandatory update required (`minimum`).
 
 	[[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
                                      serverConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,25 @@ ManUp will download a ManUp configuration file (json) that is hosted on a server
 
 Running ManUp will download this file and compare it to the installed app's version to determine if there is an update available (`latest`), or if there is a mandatory update required (`minimum`).
 
-	[[ManUp shared] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"]
-                                            delegate:self];
+#### Swift
+
+    // keep a strong reference
+    let manUp = ManUp()
+    
+    // typically in applicationDidBecomeActive
+    self.manUp.configURL = URL(string: "https://clientfiles.nextfaze.com/eva/maintenanceMode.json")
+    self.manUp.delegate = nil
+    self.manUp.validate()
+
+
+#### Objective-C
+
+    // keep a strong reference
+    @property (nonatomic, strong) ManUp *manUp;
+
+    self.manUp = [[ManUp alloc] initWithConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"] delegate:self];
+    [self.manUp validate];
+
 	
 You can also add any keys and values to the json file, which will be accessible like so:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ManUp will download a ManUp configuration file (json) that is hosted on a server
 
 Running ManUp will download this file and compare it to the installed app's version to determine if there is an update available (`latest`), or if there is a mandatory update required (`minimum`).
 
-	[[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
+	[[ManUp shared] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
                                      serverConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"]
                                             delegate:self];
 	

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The preferred method is via CocoaPods:
 
     pod 'ManUp'
 
-Alterantively, you can simply copy the folder `ManUp` into your project.
 
 ## Usage
 
@@ -23,7 +22,8 @@ ManUp will download a ManUp configuration file (json) that is hosted on a server
         "ios": {
             "url": "https://itunes.apple.com/app/id0000000?mt=8",
             "latest": "2.0",
-            "minimum": "1.1"
+            "minimum": "1.1",
+            "enabled": true
         }
     }
 
@@ -31,6 +31,8 @@ Running ManUp will download this file and compare it to the installed app's vers
 
 #### Swift
 
+	@import ManUp
+	
     // keep a strong reference
     let manUp = ManUp()
     
@@ -42,6 +44,8 @@ Running ManUp will download this file and compare it to the installed app's vers
 
 #### Objective-C
 
+    #import <ManUp/ManUp.h>
+    
     // keep a strong reference
     @property (nonatomic, strong) ManUp *manUp;
 


### PR DESCRIPTION
Brings ManUp inline with [ionic-manup](https://github.com/NextFaze/ionic-manup) by:

- updating the config.json format, now has (optional) nested `ios` object, and newer, friendlier keys `latest`, `minimum`, `url`, etc... #15 #11 
- add support for the `enabled` key, aka maintenance mode #16