### PR TITLE
Remove singleton

### DIFF
--- a/ManUp/ManUp.h
+++ b/ManUp/ManUp.h
@@ -61,7 +61,7 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 /**
  The URL pointing to the remote config.json file.
  */
-@property (nonatomic, strong, nullable) NSURL *serverConfigURL;
+@property (nonatomic, strong, nullable) NSURL *configURL;
 
 /**
  The date that the configuration was last successfully updated from the server.

--- a/ManUp/ManUp.h
+++ b/ManUp/ManUp.h
@@ -41,16 +41,16 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 
 @interface ManUp : NSObject
 
-+ (ManUp *)sharedInstance;
+- (instancetype)initWithConfigURL:(nullable NSURL *)url delegate:(nullable NSObject<ManUpDelegate> *)delegate;
 
-- (void)manUpWithDefaultDictionary:(nullable NSDictionary *)defaultSettingsDict
-                   serverConfigURL:(nullable NSURL *)serverConfigURL
-                          delegate:(nullable NSObject<ManUpDelegate> *)delegate;
+/**
+ Run the ManUp validation, if it's already running it will not start another check.
+ */
+- (void)validate;
 
-- (void)manUpWithDefaultJSONFile:(nullable NSString *)defaultSettingsPath
-                 serverConfigURL:(nullable NSURL *)serverConfigURL
-                        delegate:(nullable NSObject<ManUpDelegate> *)delegate;
-
+/**
+ A delegate to receive callbacks during the lifecycle of a validation.
+ */
 @property (nonatomic, weak, nullable) NSObject<ManUpDelegate> *delegate;
 
 /**
@@ -61,7 +61,7 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
 /**
  The URL pointing to the remote config.json file.
  */
-@property (nonatomic, readonly, nullable) NSURL *serverConfigURL;
+@property (nonatomic, strong, nullable) NSURL *serverConfigURL;
 
 /**
  The date that the configuration was last successfully updated from the server.
@@ -78,7 +78,7 @@ static NSString *const kManUpConfigAppIsEnabled         = @"enabled";
  
  @param key the key used in the config json file
  */
-+ (id)settingForKey:(NSString *)key;
+- (id)settingForKey:(NSString *)key;
 
 /** 
  String version comparison

--- a/ManUp/ManUp.m
+++ b/ManUp/ManUp.m
@@ -15,7 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
  Used to save settings used by ManUp locally to the device
  */
 static NSString *const kManUpSettings                   = @"ManUpSettings";
-static NSString *const kManUpServerConfigURL            = @"ManUpServerConfigURL";
 static NSString *const kManUpLastUpdated                = @"ManUpLastUpdated";
 
 typedef NS_ENUM(NSUInteger, ManUpAlertType) {
@@ -40,7 +39,7 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
 
 - (instancetype)initWithConfigURL:(nullable NSURL *)url delegate:(nullable NSObject<ManUpDelegate> *)delegate {
     if (self = [self init]) {
-        self.serverConfigURL = url;
+        self.configURL = url;
         self.delegate = delegate;
     }
     return self;
@@ -133,7 +132,7 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
 #pragma mark -
 
 - (void)updateFromServer {
-    if (!self.serverConfigURL) {
+    if (!self.configURL) {
         [self log:@"ERROR: No server config URL specified."];
         if ([self.delegate respondsToSelector:@selector(manUpConfigUpdateFailed:)]) {
             NSError *error = [NSError errorWithDomain:@"com.nextfaze.ManUp" code:1 userInfo:nil];
@@ -152,7 +151,7 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
         [self.delegate manUpConfigUpdateStarting];
     }
     
-    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:self.serverConfigURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60];
+    NSURLRequest *request = [[NSURLRequest alloc] initWithURL:self.configURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:60];
 
     NSURLSession *session = [NSURLSession sharedSession];
     NSURLSessionDataTask *task = [session dataTaskWithRequest:request

--- a/ManUp/ManUp.m
+++ b/ManUp/ManUp.m
@@ -31,63 +31,34 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
 @property (nonatomic, assign) ManUpAlertType currentlyShownAlertType;
 @property (nonatomic, assign) BOOL optionalUpdateShown;
 @property (nonatomic, assign) BOOL updateInProgress;
-@property (nonatomic, strong, nullable) NSURL *serverConfigURL;
 
 @end
 
 @implementation ManUp
 
-- (void)manUpWithDefaultDictionary:(nullable NSDictionary *)defaultSettingsDict serverConfigURL:(nullable NSURL *)serverConfigURL delegate:(nullable NSObject<ManUpDelegate> *)delegate {
-    self.delegate = delegate;
-    self.serverConfigURL = serverConfigURL;
-    
-    // Only apply defaults if they do not exist already.
-    if(![self hasPersistedSettings]) {
-        NSDictionary* nonNullDefaultSettings = [self replaceNullsWithEmptyStringInDictionary:defaultSettingsDict];
-        [self setManUpSettings:nonNullDefaultSettings];
-    }
-    
-    [self updateFromServer];
-}
-
-- (void)manUpWithDefaultJSONFile:(nullable NSString *)defaultSettingsPath serverConfigURL:(nullable NSURL *)serverConfigURL delegate:(nullable NSObject<ManUpDelegate> *)delegate {
-    self.delegate = delegate;
-    self.serverConfigURL = serverConfigURL;
-    
-    // Only apply defaults if they do not exist already.
-    if (![self hasPersistedSettings]) {
-        NSData *jsonData = [NSData dataWithContentsOfFile:defaultSettingsPath];
-        if (jsonData) {
-            NSError *error = nil;
-            NSDictionary *defaultSettings = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&error];
-            NSDictionary *nonNullDefaultSettings = [self replaceNullsWithEmptyStringInDictionary:defaultSettings];
-            [self setManUpSettings:nonNullDefaultSettings];
-        }
-    }
-    
-    [self updateFromServer];
-}
-
 #pragma mark - Creation
 
-+ (ManUp *)sharedInstance {
-    static id sharedInstance = nil;
-    
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedInstance = [[[self class] alloc] init];
-    });
-
-    return sharedInstance;
+- (instancetype)initWithConfigURL:(nullable NSURL *)url delegate:(nullable NSObject<ManUpDelegate> *)delegate {
+    if (self = [self init]) {
+        self.serverConfigURL = url;
+        self.delegate = delegate;
+    }
+    return self;
 }
 
-- (id)init {
+- (instancetype)init {
 	if (self = [super init]) {
 		self.updateInProgress = NO;
         self.optionalUpdateShown = NO;
         self.currentlyShownAlertType = ManUpAlertTypeNone;
 	}
 	return self;
+}
+
+#pragma mark - Public
+
+- (void)validate {
+    [self updateFromServer];
 }
 
 #pragma mark - 
@@ -148,10 +119,6 @@ typedef NS_ENUM(NSUInteger, ManUpAlertType) {
         object = iOSSettings[resolvedKey];
     }
     return object;
-}
-
-+ (id)settingForKey:(NSString *)key {
-    return [[ManUp sharedInstance] settingForKey:key];
 }
 
 - (void)log:(NSString *)string, ... NS_FORMAT_FUNCTION(1,2) {

--- a/ManUpDemo/ManUpDemo/DemoViewController.m
+++ b/ManUpDemo/ManUpDemo/DemoViewController.m
@@ -96,7 +96,7 @@
         self.manUp.customConfigKeyMapping = nil;
     }
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:serverPath];
+    self.manUp.configURL = [NSURL URLWithString:serverPath];
     [self.manUp validate];
 }
 

--- a/ManUpDemo/ManUpDemo/DemoViewController.m
+++ b/ManUpDemo/ManUpDemo/DemoViewController.m
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) NSArray *testItems;
 
+@property (nonatomic, strong) ManUp *manUp;
 @property (nonatomic, strong) NSString *lastUsedFilename;
 
 @end
@@ -33,6 +34,10 @@
     }
     
     self.testItems = testItems;
+    
+    self.manUp = [[ManUp alloc] init];
+    self.manUp.delegate = self;
+    self.manUp.enableConsoleLogging = YES;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(applicationDidBecomeActive) name:UIApplicationDidBecomeActiveNotification object:nil];
     
@@ -79,23 +84,20 @@
     
     NSString *serverPath = [@"https://github.com/NextFaze/ManUp/raw/develop/ManUpDemo/TestFiles/" stringByAppendingString:fileName];
     
-    [ManUp sharedInstance].enableConsoleLogging = YES;
-    
     if ([fileName isEqualToString:@"TestCustomConfigKeys.json"]) {
         // Don't like the json keys used by ManUp? Specify your own with a custom mapping dictionary
-        [ManUp sharedInstance].customConfigKeyMapping = @{
-                                                          kManUpConfigAppVersionCurrent: @"app_store_version_current",
-                                                          kManUpConfigAppVersionMin: @"minimum_allowed_version",
-                                                          kManUpConfigAppUpdateURL: @"app_update_url"
-                                                          };
+        self.manUp.customConfigKeyMapping = @{
+                                              kManUpConfigAppVersionCurrent: @"app_store_version_current",
+                                              kManUpConfigAppVersionMin: @"minimum_allowed_version",
+                                              kManUpConfigAppUpdateURL: @"app_update_url"
+                                              };
         
     } else {
-        [ManUp sharedInstance].customConfigKeyMapping = nil;
+        self.manUp.customConfigKeyMapping = nil;
     }
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:[fileName stringByDeletingPathExtension] ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:serverPath]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:serverPath];
+    [self.manUp validate];
 }
 
 #pragma mark - UITableViewDataSource

--- a/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
+++ b/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
@@ -47,7 +47,7 @@
 }
 
 - (void)testConfigInvalidURL {
-    self.manUp.serverConfigURL = nil;
+    self.manUp.configURL = nil;
     [self.manUp validate];
     
     XCTAssert(self.failed == YES);
@@ -55,7 +55,7 @@
 }
     
 - (void)testConfigVersionsEqual {
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
@@ -76,7 +76,7 @@
     NSInteger lowerMajorVersion = operatingSystemMajorVersion - 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)lowerMajorVersion];
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is lower than the OS version"];
@@ -98,7 +98,7 @@
     NSInteger operatingSystemMajorVersion = [versionComponents[0] integerValue];
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)operatingSystemMajorVersion];
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is the same (major) as the OS version"];
@@ -121,7 +121,7 @@
     NSInteger higherMajorVersion = operatingSystemMajorVersion + 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)higherMajorVersion];
     
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update exists but is not available as the update's deployment target is higher than the OS version"];
@@ -135,7 +135,7 @@
 }
 
 - (void)testMaintenanceMode {
-    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]];
+    self.manUp.configURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]];
     [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with maintenance mode is true"];

--- a/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
+++ b/ManUpDemo/ManUpDemoTests/ManUpDemoTests.m
@@ -14,6 +14,7 @@
 @interface ManUpDemoTests : XCTestCase <ManUpDelegate>
 
 @property (nonatomic, strong) XCTestExpectation *expectation;
+@property (nonatomic, strong) ManUp *manUp;
 @property (nonatomic, assign) BOOL updated;
 @property (nonatomic, assign) BOOL failed;
 @property (nonatomic, assign) BOOL updateAvailable;
@@ -27,7 +28,8 @@
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
-    [ManUp sharedInstance].enableConsoleLogging = YES;
+    self.manUp = [[ManUp alloc] initWithConfigURL:nil delegate:self];
+    self.manUp.enableConsoleLogging = YES;
 }
 
 - (void)tearDown {
@@ -37,53 +39,24 @@
     self.failed = NO;
     self.updateAvailable = NO;
     self.updateRequired = NO;
-    [ManUp sharedInstance].optionalUpdateShown = NO;
 }
 
 - (void)testManUpSettingForKey {
-    id setting = [ManUp settingForKey:@"made-up-key"];
+    id setting = [self.manUp settingForKey:@"made-up-key"];
     XCTAssertNil(setting, @"There should be no setting for this made up key.");
 }
 
 - (void)testConfigInvalidURL {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestVersionsEqual" ofType:@"json"]
-                                     serverConfigURL:nil
-                                            delegate:self];
+    self.manUp.serverConfigURL = nil;
+    [self.manUp validate];
     
     XCTAssert(self.failed == YES);
     XCTAssert(self.updated == NO);
 }
-
-- (void)testConfigWithIncorrectJSONFile {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"ThisFileDoesntExist" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]]
-                                            delegate:self];
-
-    self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
-    
-    [self waitForExpectationsWithTimeout:60.0 handler:nil];
-    
-    XCTAssert(self.failed == NO);
-    XCTAssert(self.updated == YES);
-}
-
-- (void)testConfigWithNilJSONFile {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:nil
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]]
-                                            delegate:self];
-    
-    self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
-    
-    [self waitForExpectationsWithTimeout:60.0 handler:nil];
-    
-    XCTAssert(self.failed == NO);
-    XCTAssert(self.updated == YES);
-}
     
 - (void)testConfigVersionsEqual {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestVersionsEqual" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestVersionsEqual.json", ServerConfigPath]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with versions equal"];
     
@@ -103,9 +76,8 @@
     NSInteger lowerMajorVersion = operatingSystemMajorVersion - 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)lowerMajorVersion];
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:testFilename ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is lower than the OS version"];
     
@@ -126,9 +98,8 @@
     NSInteger operatingSystemMajorVersion = [versionComponents[0] integerValue];
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)operatingSystemMajorVersion];
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:testFilename ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update available as the update's deployment target is the same (major) as the OS version"];
     
@@ -150,9 +121,8 @@
     NSInteger higherMajorVersion = operatingSystemMajorVersion + 1;
     NSString *testFilename = [NSString stringWithFormat:@"TestUpgradeAvailableDeploymentTarget%ld", (long)higherMajorVersion];
     
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:testFilename ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@%@.json", ServerConfigPath, testFilename]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp update exists but is not available as the update's deployment target is higher than the OS version"];
     
@@ -165,9 +135,8 @@
 }
 
 - (void)testMaintenanceMode {
-    [[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"TestMaintenanceMode" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]]
-                                            delegate:self];
+    self.manUp.serverConfigURL = [NSURL URLWithString:[NSString stringWithFormat:@"%@TestMaintenanceMode.json", ServerConfigPath]];
+    [self.manUp validate];
     
     self.expectation = [self expectationWithDescription:@"ManUp with maintenance mode is true"];
     

--- a/README.md
+++ b/README.md
@@ -29,9 +29,25 @@ ManUp will download a ManUp configuration file (json) that is hosted on a server
 
 Running ManUp will download this file and compare it to the installed app's version to determine if there is an update available (`latest`), or if there is a mandatory update required (`minimum`).
 
-	[[ManUp shared] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
-                                     serverConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"]
-                                            delegate:self];
+#### Swift
+
+    // keep a strong reference
+    let manUp = ManUp()
+    
+    // typically in applicationDidBecomeActive
+    self.manUp.configURL = URL(string: "https://clientfiles.nextfaze.com/eva/maintenanceMode.json")
+    self.manUp.delegate = nil
+    self.manUp.validate()
+
+
+#### Objective-C
+
+    // keep a strong reference
+    @property (nonatomic, strong) ManUp *manUp;
+
+    self.manUp = [[ManUp alloc] initWithConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"] delegate:self];
+    [self.manUp validate];
+
 	
 You can also add any keys and values to the json file, which will be accessible like so:
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ManUp will download a ManUp configuration file (json) that is hosted on a server
 
 Running ManUp will download this file and compare it to the installed app's version to determine if there is an update available (`latest`), or if there is a mandatory update required (`minimum`).
 
-	[[ManUp sharedInstance] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
+	[[ManUp shared] manUpWithDefaultJSONFile:[[NSBundle mainBundle] pathForResource:@"config_manup" ofType:@"json"]
                                      serverConfigURL:[NSURL URLWithString:@"https://yourserver.com/config.json"]
                                             delegate:self];
 	

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The preferred method is via CocoaPods:
 
     pod 'ManUp'
 
-Alterantively, you can simply copy the folder `ManUp` into your project.
 
 ## Usage
 
@@ -23,7 +22,8 @@ ManUp will download a ManUp configuration file (json) that is hosted on a server
         "ios": {
             "url": "https://itunes.apple.com/app/id0000000?mt=8",
             "latest": "2.0",
-            "minimum": "1.1"
+            "minimum": "1.1",
+            "enabled": true
         }
     }
 
@@ -31,6 +31,8 @@ Running ManUp will download this file and compare it to the installed app's vers
 
 #### Swift
 
+	@import ManUp
+	
     // keep a strong reference
     let manUp = ManUp()
     
@@ -42,6 +44,8 @@ Running ManUp will download this file and compare it to the installed app's vers
 
 #### Objective-C
 
+    #import <ManUp/ManUp.h>
+    
     // keep a strong reference
     @property (nonatomic, strong) ManUp *manUp;
 


### PR DESCRIPTION
Remove the shared instance property

The pattern of a singleton with a delegate is a bit gross. This removes
the singleton property, and adds a constructor that takes the url and a
delegate.

Bonus: this refactor removes the default dictionary/json file as it is
rarely (never) used in practice.

Also rename serverConfigURL to configURL and update the readme.